### PR TITLE
誤爆防止機能の追加、`README`の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-/.gradle
-/local.properties
-/.idea

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,0 @@
-/build
-/app.iml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,13 @@
 apply plugin: 'com.android.application'
-
 android {
     compileSdkVersion 22
     buildToolsVersion "21.1.2"
-
     defaultConfig {
         applicationId "jp.co.benesse.touch.setuplogin"
         minSdkVersion 22
-        //noinspection OldTargetApi
         targetSdkVersion 22
-        versionCode 2
-        versionName "1.0.1"
+        versionCode 3
+        versionName "1.1.0"
     }
     buildTypes {
         debug {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,24 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="jp.co.benesse.touch.setuplogin">
-    <uses-permission android:name="android.permission.WRITE_SETTINGS"
-        tools:ignore="ProtectedPermissions" />
+
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+
     <application
-        android:allowBackup="false"
-        android:label="@string/app_name"
         android:icon="@drawable/ic_launcher"
-        android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning">
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
+
         <activity
-            android:label="@string/app_name"
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
     </application>
+
 </manifest>

--- a/app/src/main/java/jp/co/benesse/touch/setuplogin/MainActivity.java
+++ b/app/src/main/java/jp/co/benesse/touch/setuplogin/MainActivity.java
@@ -2,12 +2,22 @@ package jp.co.benesse.touch.setuplogin;
 
 import android.app.Activity;
 import android.os.Bundle;
+
+import java.io.File;
+
 import static android.provider.Settings.System.putInt;
 
 public class MainActivity extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // DchaStateが３に成った形跡が無い場合
+        if (!(new File("/factory/count_dcha_completed")).exists()) {
+            // 文字表示
+            setContentView(R.layout.ignore);
+            // 処理停止
+            return;
+        }
         // 文字表示
         setContentView(R.layout.main);
         // DchaStateを 3 に変更

--- a/app/src/main/res/layout/ignore.xml
+++ b/app/src/main/res/layout/ignore.xml
@@ -1,0 +1,11 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:text="@string/ignore"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <string name="app_name">DchaState 3 Changer</string>
-    <string name="message">DchaStateを 3 に変更しました｡\nナビゲーションバーを表示しました｡</string>
+    <string name="message">DchaStateを 3 に変更しました｡\nナビゲーションバーを有効にしました｡</string>
+    <string name="ignore">DchaStateが３になった形跡が無いため､\nこのアプリを実行する必要はありません｡</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,9 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.+'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,14 @@
 
 このツールの使用によって起きた損害については保証しません｡
 
+また､ `Cpad_dcha_3_changer`は､ **一時的に**開発者向けオプションのロックを回避するためのアプリです｡  
+簡易セットアップ後も開発者向けオプションを利用する場合は､ [**BypassDchaLock**](https://github.com/s1204IT/BypassDchaLock) を使って下さい｡
+
 ## 必要なもの
 
 *   チャレンジパッド Neo/Next
 *   Windows, Linux, Mac OS搭載のPC
+*   ADB環境
 *   USB 2.0 Mini-B ケーブル
 
 ## 準備
@@ -76,7 +80,7 @@ Query: (空欄)
 
 ６，５の画像下部の`Add`を押します｡
 
-![](https://user-images.githubusercontent.com/52069677/205293357-9fe6e4df-daa1-4062-9905-c54dddb51cbe.png)
+![](https://user-images.githubusercontent.com/52069677/209759334-c6b0e806-a21c-4038-b314-9e3b494f9a68.png)
 
 設定値は次の通りです｡
 
@@ -89,7 +93,7 @@ https://townak.benesse.ne.jp/rel/A/sp_84/open/TouchSetupLogin.apk
 
 Replace -  Value:
 ```
-https://github.com/mouseos/Cpad_dcha_3_changer/releases/download/Ver1.0.1/app-release.apk
+https://github.com/mouseos/Cpad_dcha_3_changer/releases/latest/download/app-release.apk
 ```
 
 `Replace all`を選択
@@ -178,39 +182,26 @@ https://github.com/mouseos/Cpad_dcha_3_changer/releases/download/Ver1.0.1/app-re
 
 １９，`USBデバッグ`をオンにします｡
 
-２０，PCで以下のアプリのAPKファイルをダウンロードします｡
+２０，PCで以下のADBコマンドを実行します｡
+```
+adb shell pm uninstall --user 0 jp.co.benesse.dcha.dchaservice
+```
 
-CPad Customize Tool  
-[https://github.com/Kobold831/CPadCustomizeTool/releases](https://github.com/Kobold831/CPadCustomizeTool/releases)
-
-Aurora Store for NEO  
-[https://github.com/Kobold831/AuroraStore4/releases](https://github.com/Kobold831/AuroraStore4/releases)
+２１，PCで以下のアプリのAPKファイルをダウンロードします｡
 
 Nova Launcher  
 [https://teslacoilapps.com/tesladirect/download.pl?packageName=com.teslacoilsw.launcher](https://teslacoilapps.com/tesladirect/download.pl?packageName=com.teslacoilsw.launcher)
 
-２１，ダウンロードしたapkのあるディレクトリで以下のコマンドを実行します｡
+２２，ダウンロードしたAPKのあるディレクトリで以下のコマンドを実行します｡
 ```
-adb install [それぞれのapkのファイル名]
-```
-```
-adb shell pm grant com.saradabar.cpadcustomizetool android.permission.WRITE_SECURE_SETTINGS
-```
-```
-adb shell dpm set-device-owner com.saradabar.cpadcustomizetool/.Receiver.AdministratorReceiver
+adb install .\NovaLauncher_[version].apk
 ```
 ```
 adb shell pm set-home-activity --user 0 com.teslacoilsw.launcher/.NovaLauncher
 ```
-※ADBコマンドがない場合はインストールしてください｡ 入れ方は各自調べてください｡  
-また､ **カスタマイズツール**及び**Aurora Store for NEO**の**動作は保証致しません**｡
 
-２２，チャレンジパッドのホームボタンを押します｡
+２３，チャレンジパッドのホームボタンを押します｡
 
-２３，Nova Launcherの初期設定をします｡
+２４，Nova Launcherの初期設定をします｡
 
-２４，カスタマイズツールを開きます｡
-
-２５，システムUIを通常用に変更とナビゲーションバーの表示を維持をオンにします｡
-
-２６，これで改造完了です｡
+２５，これで改造完了です｡


### PR DESCRIPTION
## 変更点
- `.gitignore`を削除
- `AndroidManifest.xml`の整形及び修正
  - `tools`の宣言を全て削除
  - `allowBackup`の宣言を削除
- `MainActivity.java`の修正
  - `/factory/count_dcha_completed`の存在を確認して誤爆を防止
- `README`の修正
  - `BypassDchaLock`について
  - 再起動後に自動アンインストールを避けるため､ `DchaService`のアンインストールコマンドを追加
  - 某Laboのアプリを削除
    - TestDPCの日本語訳を追加する予定なので､ 暫しお待ち下さい｡
---
### APK
- [app-release.apk.zip](https://github.com/mouseos/Cpad_dcha_3_changer/files/10312264/app-release.apk.zip)
